### PR TITLE
Add a traits module and example of using it

### DIFF
--- a/traitexample.py
+++ b/traitexample.py
@@ -1,0 +1,50 @@
+import logging
+import random
+import traits
+
+logging.basicConfig(filename='debug.txt',level=logging.DEBUG, filemode='w')
+
+class Allele:
+    def __init__(self, type):
+        self.type = type
+
+class Organism(dict):
+    def __init__(self, alleles, traits, id):
+        self.id = id
+        self.alleles = alleles
+        self.traits = traits
+        for trait in traits:
+            trait.attach(self)
+        logging.debug(f'Creating Organism: {self.id}')
+
+    def __getattr__(self, name):
+        # return something when requesting an attribute that doesnt exist on this instance
+        return None
+
+def main():
+    # predefine some alleles
+    red = Allele("red")
+    blue = Allele("blue")
+    green = Allele("green")
+
+    # make an organism without the Coloration trait
+    # it has the alleles, but not the trait to use them
+    uncoloredOrganism = Organism([blue, blue, green], [], "o0")
+    logging.debug(f'Organism {uncoloredOrganism.id} hasattr {hasattr(uncoloredOrganism, "has_color")}, has_color: {uncoloredOrganism.has_color}')
+
+    # make an organism with the Coloration trait
+    bluishOrganism = Organism([blue, blue, green], [traits.Coloration], "o1")
+    logging.debug(f'Organism {bluishOrganism.id} has_color: {bluishOrganism.has_color}, redness: {bluishOrganism.redness}, greenness: {bluishOrganism.greenness}, blueness: {bluishOrganism.blueness}')
+
+    # add an efficiency trait
+    bluishOrganism.traits.append(traits.Efficiency)
+    traits.Efficiency.attach(bluishOrganism)
+    logging.debug(f'Organism {bluishOrganism.id} efficiency: {bluishOrganism.efficiency}')
+
+    # this one has the efficiency trait, but not the coloration trait
+    hungryOrganism = Organism([blue, blue, green], [traits.Efficiency], "o2")
+    logging.debug(f'Organism {hungryOrganism.id} efficiency: {hungryOrganism.efficiency}')
+
+
+if __name__ == "__main__":
+    main()

--- a/traits.py
+++ b/traits.py
@@ -1,0 +1,39 @@
+class Trait(dict):
+    allele_ids = []
+    def attach(self, attachee):
+        self.update(attachee)
+    def detach(self, attachee):
+        # TODO: unattach by resetting any organism properties we set
+        pass
+
+class _ColorationTrait(Trait):
+    allele_ids = ["red", "blue", "green"]
+    def attach(self, organism):
+        organism.has_color = True
+        super().attach(organism)
+    def update(self, organism):
+        color_alleles = list(filter(lambda allele: allele.type in self.allele_ids, organism.alleles))
+        r = 0
+        g = 0
+        b = 0
+        for allele in color_alleles:
+            if allele.type == "red":
+                r += 255/2
+            elif allele.type == "green":
+                g += 255/2
+            elif allele.type == "blue":
+                b += 255/2
+        organism.greenness = max(0, g - ((r + b)/2))
+        organism.redness = max(0, r - ((b + g)/2))
+        organism.blueness = max(0, b - ((r + g)/2))
+
+
+class _Efficiency(Trait):
+    def update(self, organism):
+      if organism.has_color:
+        organism.efficiency = organism.blueness/255
+      else:
+        organism.efficiency = 0.1
+
+Coloration = _ColorationTrait()
+Efficiency = _Efficiency()


### PR DESCRIPTION
Using a module lets use tuck away the classes for each trait. When you import the `traits` module, we can just use the instances we created from the classes and not worry about how they are implemented - with a class or whatever. 

You can see in the example, one trait directly computes an attribute value from the alleles of the attached organism. But the other example trait just uses that computed value to calculate a new thing. 

There's some details to work out here - like when we call update and how we ensure the traits are updated in order to get the right result for this kind of dependent trait. But hopefully you get the idea? 